### PR TITLE
Updating CLI to ^1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "zone.js": "^0.8.4"
   },
   "devDependencies": {
-    "@angular/cli": "1.1.2",
+    "@angular/cli": "^1.2.6",
     "@angular/compiler-cli": "^4.0.0",
     "@angular/language-service": "^4.0.0",
     "@types/jasmine": "2.5.45",


### PR DESCRIPTION
Current Scenario : Angular CLI 1.1.2 Throws Issue #35 
-------------------------------------------------------------------------------------------------------
ERROR in ./src/main.ts
Module build failed: TypeError: Cannot read property 'newLine' of undefined
    at Object.getNewLineCharacter (/home/pratik/WebstormProjects/playground/playground/node_modules/typescript/lib/typescript.js:9618:20)
    at Object.createCompilerHost (/home/pratik/WebstormProjects/playground/playground/node_modules/typescript/lib/typescript.js:66867:26)
    at Object.ngcLoader (/home/pratik/WebstormProjects/playground/playground/node_modules/@ngtools/webpack/src/loader.js:397:33)
 @ multi webpack-dev-server/client?http://localhost:4201 ./src/main.ts

ERROR in ./src/polyfills.ts
Module build failed: TypeError: Cannot read property 'newLine' of undefined
    at Object.getNewLineCharacter (/home/pratik/WebstormProjects/playground/playground/node_modules/typescript/lib/typescript.js:9618:20)
    at Object.createCompilerHost (/home/pratik/WebstormProjects/playground/playground/node_modules/typescript/lib/typescript.js:66867:26)
    at Object.ngcLoader (/home/pratik/WebstormProjects/playground/playground/node_modules/@ngtools/webpack/src/loader.js:397:33)
 @ multi ./src/polyfills.ts
--------------------------------------------------------------------------------
Node -> 8.2.1
Npm-> 5.2.3
Ubuntu 17.04

------------Fix---------
Upgraded CLI to 1.2.6